### PR TITLE
Link and fav+rt commands

### DIFF
--- a/weetweet.py
+++ b/weetweet.py
@@ -330,8 +330,8 @@ def stream_message(buffer,tweet):
                 extra_str = "'s tweet " + arrow_col +  "<" + reset_col + dict_id + arrow_col + "> " + reset_col
 
         #TODO make the event printing better
-        weechat.prnt(buffer, "%s%s" % (weechat.prefix("network"),
-        tweet['source']['screen_name'] + " " + event_str + " " + tweet['target']['screen_name'] + extra_str))
+        weechat.prnt_date_tags(buffer, 0, "no_highlight", "%s%s" % (weechat.prefix("network"),
+            tweet['source']['screen_name'] + " " + event_str + " " + tweet['target']['screen_name'] + extra_str))
     else:
         weechat.prnt(buffer, "%s%s" % (weechat.prefix("network"),
         "recv stream data: " + str(tweet)))

--- a/weetweet.py
+++ b/weetweet.py
@@ -95,7 +95,7 @@ command_dict = dict(user="u",replies="r",view_tweet="v",thread="th",link="l",
         follow_user="follow",unfollow_user="unfollow",following="f",
         followers="fo",about="a",block="b",unblock="ub",
         blocked_users="blocks",favorite="fav",unfavorite="unfav",
-        favorites="favs", rate_limits="limits",home_timeline="home",
+        favorites="favs",fav_retweet="fart",rate_limits="limits",home_timeline="home",
         clear_nicks="cnicks",clear_buffer="clear",create_stream="stream",
         restart_home_stream="re_home")
 desc_dict = dict(
@@ -137,6 +137,7 @@ desc_dict = dict(
         "if <user> is not given get your own favs. " +
         "If <id> is given it will get tweets older than <id>, " +
         "<count> is how many tweets to get, valid number is 1-200",
+        fav_retweet="<id>, favorites and retweets <id>",
         rate_limits="[|<sub_group>], get the current status of the twitter " +
         "api limits. It prints how much you have left/used. " +
         " if <sub_group> is supplied it will only get/print that sub_group.",
@@ -790,6 +791,10 @@ def get_twitter_data(cmd_args):
                 tweet_data = twitter.favorites.list(**kwargs)
             else:
                 tweet_data = twitter.favorites.list()
+        elif cmd_args[3] == "fart":
+            twitter.favorites.create(_id=cmd_args[4])
+            tweet_data = [twitter.statuses.retweet._(cmd_args[4])()]
+            tweet_data = []
         elif cmd_args[3] == "limits":
             output = ""
             if len(cmd_args) >= 5:
@@ -944,6 +949,10 @@ def buffer_input_cb(data, buffer, input_data):
         elif command == 'unfav' and tweet_dict.get(input_args[1]):
             input_data = 'unfav ' + tweet_dict[input_args[1]]
             weechat.prnt(buffer, "%sYou unfave'd the following tweet:" % weechat.prefix("network"))
+        elif command == 'fart' and tweet_dict.get(input_args[1]):
+            end_message = "id"
+            input_data = 'fart ' + tweet_dict[input_args[1]]
+            weechat.prnt(buffer, "%sYou fave'd and retweeted the following tweet:" % weechat.prefix("network"))
         elif command == 'cnicks':
             global tweet_nicks_group
             if tweet_nicks_group[buffer] != "":

--- a/weetweet.py
+++ b/weetweet.py
@@ -64,9 +64,9 @@ try:
         import_ok = False
 except:
     if weechat_call:
-        weechat.prnt("", "You need the have pkg_resources installed for version checking")
+        weechat.prnt("", "You need to have pkg_resources installed for version checking")
     else:
-        print("You need the have pkg_resources installed for version checking")
+        print("You need to have pkg_resources installed for version checking")
 
 # These two keys is what identifies this twitter client as "weechat twitter"
 # If you want to change it you can register your own keys at:

--- a/weetweet.py
+++ b/weetweet.py
@@ -90,7 +90,7 @@ script_options = {
 #TODO have a dict for each buffer
 tweet_dict = {'cur_index': "a0"}
 #Mega command dict
-command_dict = dict(user="u",replies="r",view_tweet="v",thread="th",
+command_dict = dict(user="u",replies="r",view_tweet="v",thread="th",link="l",
         retweet="rt",delete="d",tweet="t",reply="re",new_tweets="new",
         follow_user="follow",unfollow_user="unfollow",following="f",
         followers="fo",about="a",block="b",unblock="ub",
@@ -108,6 +108,7 @@ desc_dict = dict(
         view_tweet="<id>, View/get tweet with <id>",
         thread="<id>, View/get the reply chain of tweets (the thread) where " +
         "<id> is the last tweet in the thread.",
+        link="<id>, Get a link to tweet with <id>",
         retweet="<id>, Retweet <id>",
         delete="<id>, Delete tweet <id>. You can only delete your own tweets...",
         tweet="<text>Tweet the text following this command",
@@ -692,6 +693,11 @@ def get_twitter_data(cmd_args):
                     tweet_id = temp_tweet["in_reply_to_status_id_str"]
                 else:
                     break;
+        elif cmd_args[3] == "l":
+            tweet_data = [twitter.statuses.show._(cmd_args[4])()]
+            output = "Link for tweet: https://twitter.com/{}/status/{}".format(tweet_data[0]['user']['screen_name'],
+                                                                               tweet_data[0]['id_str'])
+            return output
         elif cmd_args[3] == "rt":
             tweet_data = [twitter.statuses.retweet._(cmd_args[4])()]
             #The home stream prints you messages as well...
@@ -851,6 +857,8 @@ def buffer_input_cb(data, buffer, input_data):
         elif command == 'th' and tweet_dict.get(input_args[1]):
             input_data = 'th ' + tweet_dict[input_args[1]]
             end_message = "Done"
+        elif command == 'l' and tweet_dict.get(input_args[1]):
+            input_data = 'l ' + tweet_dict[input_args[1]]
         elif command == 'rt' and tweet_dict.get(input_args[1]):
             end_message = "id"
             input_data = 'rt ' + tweet_dict[input_args[1]]

--- a/weetweet.py
+++ b/weetweet.py
@@ -279,12 +279,16 @@ def trim_tweet_data(tweet_data, screen_name, alt_rt_style):
 
     output = []
     for message in tweet_data:
-        if alt_rt_style and message.get('retweeted_status'):
-            if message['user']['screen_name'] == screen_name:
-                #escape highlighting
-                message['user']['screen_name'] = "<you>"
-            message['text'] = message['retweeted_status']['text'] + " (retweeted by " + message['user']['screen_name'] + ")"
-            message['user'] = message['retweeted_status']['user']
+        if message.get('retweeted_status'):
+            if alt_rt_style:
+                if message['user']['screen_name'] == screen_name:
+                    #escape highlighting
+                    message['user']['screen_name'] = "<you>"
+                message['text'] = message['retweeted_status']['text'] + " (retweeted by " + message['user']['screen_name'] + ")"
+                message['user'] = message['retweeted_status']['user']
+            else:
+                message['text'] = "RT @{}: {}".format(message['retweeted_status']['user']['screen_name'],
+                                                      message['retweeted_status']['text'])
         mes_list = [calendar.timegm(time.strptime(message['created_at'],'%a %b %d %H:%M:%S +0000 %Y')),
             message['user']['screen_name'],
             message['id_str'],


### PR DESCRIPTION
`:l <id>` prints a link to the tweet.
`:fart <id>` favourites and retweets a tweet.

I'm happy to change the name of 'fart' if you don't want it named that :P

Also included:
 - have the normal retweet style show the full tweet (no more …)
 - don't highlight the user when they do actions that print their username (fav, retweet, etc)
 - fix some typos