### PR TITLE
Make the length of tweet indexes adjustable

### DIFF
--- a/weetweet.py
+++ b/weetweet.py
@@ -25,6 +25,8 @@ import time
 import calendar
 import socket
 import getpass
+import string
+import itertools
 
 # This twitter plugin can be extended even more. Just look at the twitter api
 # doc here: https://dev.twitter.com/docs/api/1.1
@@ -80,19 +82,22 @@ CONSUMER_SECRET = 'ivx3oxxkSOAOofRuhmGXQK4nkLFNXD94wbJiRUBhN1g'
 CONSUMER_KEY = 'NVkYe8DAeaw6YRcjw662ZQ'
 
 script_options = {
-    "oauth_token" : "",
-    "oauth_secret" : "",
-    "auth_complete" : False,
-    "screen_name" : "",
-    "last_id" : "",
-    "print_id" : True,
-    "alt_rt_style" : False,
-    "home_replies" : False,
-    "tweet_nicks" : True,
+    "oauth_token" : ("", "your twitter oauth token"),
+    "oauth_secret" : ("", "your twitter oath secret"),
+    "auth_complete" : (False, "whether you've finished the auth process or not"),
+    "screen_name" : ("", "your twitter username"),
+    "last_id" : ("", "the ID of the most recent tweet"),
+    "print_id" : (True, "display short tweet indexes"),
+    "alt_rt_style" : (False, "use alternate retweet display style"),
+    "home_replies" : (False, "show replies on the home timeline"),
+    "tweet_nicks" : (True, "add twitter usernames to the nicklist"),
+    "index_pattern": ("an", "a pattern of character groups to build "
+                            "short tweet indexes from. the default 'an' generates "
+                            "looping indexes from a0 to z9. a = [a-z], n = [0-9]"),
 }
 
 #TODO have a dict for each buffer
-tweet_dict = {'cur_index': "a0"}
+tweet_dict = {'cur_index': None}
 #Mega command dict
 command_dict = dict(
     user="u", replies="r", view_tweet="v", thread="th", link="l",
@@ -184,17 +189,29 @@ def html_escape(text):
     """Produce entities within text."""
     return "".join(html_escape_table.get(c, c) for c in text)
 
+def index_gen():
+    #Generates indexes starting from a0 going up to z9, then repeating
+    #index_pattern is a pattern of character groups to use for each part of the index
+    # a = [a-z]
+    # n = [0-9]
+    #This setting needs a script reload to take effect
+    index_parts = []
+    for p in script_options['index_pattern']:
+        if p == 'a':
+            index_parts.append(string.ascii_lowercase)
+        elif p == 'n':
+            index_parts.append(string.digits)
+
+    while True:
+        for index in itertools.product(*index_parts):
+            yield "".join(index)
+#Create our index generator
+index_generator = index_gen()
+
 def dict_tweet(tweet_id):
     cur_index = tweet_dict['cur_index']
     if not tweet_id in tweet_dict.values():
-        if cur_index == 'z9':
-            cur_index = 'a0'
-
-        if cur_index[1] == '9':
-            cur_index = chr(ord(cur_index[0]) + 1) + '0'
-        else:
-            cur_index = cur_index[0] + chr(ord(cur_index[1]) + 1)
-
+        cur_index = index_generator.next()
         tweet_dict[cur_index] = tweet_id
         tweet_dict['cur_index'] = cur_index
         return cur_index
@@ -1008,8 +1025,9 @@ def buffer_input_cb(data, buffer, input_data):
             input_data = 'rt ' + tweet_dict[input_args[1]]
         elif command == 're' and tweet_dict.get(input_args[1]):
             end_message = "id"
-            input_data = 're ' + tweet_dict[input_args[1]] + " '" + html_escape(input_data[6:]) \
-                    + "'"
+            len_id = len(tweet_dict['cur_index'])
+            input_data = 're ' + tweet_dict[input_args[1]] \
+                    + " '" + html_escape(input_data[(2+1+len_id+1):]) + "'"
         elif command == 'new':
             end_message = "id"
             if script_options['last_id'] != "":
@@ -1376,14 +1394,19 @@ if __name__ == "__main__" and weechat_call:
 
         #Set register script options if not available
 
-        for option, default_value in script_options.items():
+        for option, value in list(script_options.items()):
+            default_value = value[0]
+            description = value[1]
+            if isinstance(default_value, bool):
+                if default_value:
+                    default_value = "on"
+                else:
+                    default_value = "off"
+            weechat.config_set_desc_plugin(option,
+                                           description + ' (default: "' + default_value + '")')
             if not weechat.config_is_set_plugin(option):
-                if isinstance(default_value, bool):
-                    if default_value:
-                        default_value = "on"
-                    else:
-                        default_value = "off"
                 weechat.config_set_plugin(option, default_value)
+                script_options[option] = default_value
 
         read_config()
         #Hook for config changes


### PR DESCRIPTION
This PR lets you adjust the length of tweet indexes via index_length, defaulting to the current length of 2.

If set to 3, indexes will run from aa0 to zz9
4 gives aaa0 to zzz9, and so on

This setting currently requires a script reload to take effect, you'd need to replace the generator in read_config to fix that.